### PR TITLE
Fixed bug where too much cuddling broke Sweetiebot

### DIFF
--- a/modules/ResponsesFile.py
+++ b/modules/ResponsesFile.py
@@ -47,6 +47,12 @@ class ResponsesFile(object):
                 random.shuffle(self.responses)
             self.sass_index = -1
         self.sass_index += 1
+
+        if self.sass_index >= len(self.responses):
+            log.debug("reshuffling sass")
+            random.shuffle(self.responses)
+            self.sass_index = 0
+
         response = self.responses[self.sass_index]
         log.debug("returning response {}: {}".format(self.sass_index, response))
         return response


### PR DESCRIPTION
The `get_next` method in `ResponseFile` doesn't perform bounds checking. This means that if sweetiebot is pinged enough times with `/me` then `sass_index` will go past the array bounds and produce an `IndexError`.

```
(5:09) Vinyl Scratch complains to Sweetiebot about ES6
(5:09) Sweetiebot complains to Vinyl Scratch about Python :sweetie:
... to a private chat ...
(5:12) Vinyl Scratch tests sweetiebot
(5:12) sweetiebutt@friendshipismagicsquad.com puts Vinyl Scratch into a blender :sweetiesmug:
(5:12) Vinyl Scratch tests sweetiebot
(5:12) sweetiebutt@friendshipismagicsquad.com drags Vinyl Scratch off to the cardboard box :sweetiesmug:
... SNIP 10 ping/resonse pairs ...
(5:15) Vinyl Scratch tests sweetiebot more
(5:15) sweetiebutt@friendshipismagicsquad.com takes the axiom of choice and duplicates Vinyl Scratch :sweetiesmug:
(5:15) Vinyl Scratch tests sweetiebot more
(5:15) sweetiebutt@friendshipismagicsquad.com: [IndexError] My code is problematic :sweetieoops:
... back to general ...
(5:16) Vinyl Scratch breaks Sweetiebot
(5:16) Sweetiebot: [IndexError] My code is problematic :sweetieoops:
```
