### PR TITLE
Fix messages not showing up in certain clients by giving them an ID

### DIFF
--- a/modules/MUCJabberBot.py
+++ b/modules/MUCJabberBot.py
@@ -30,6 +30,9 @@ class MUCJabberBot():
         # disable ipv6 for now since we're getting errors using it
         bot.use_ipv6 = False
 
+	# Fix certain Jabber clients not showing messages by giving them an ID
+	bot.use_message_ids = True
+
         bot.add_event_handler('session_start', self.on_start)
         bot.add_event_handler('message', self.on_message)
         bot.add_event_handler('groupchat_presence', self.on_presence)


### PR DESCRIPTION
Xabber is shit and doesn't show messages if they don't have an ID. Fixed this in https://github.com/Woll0r/cardboardbot/commit/267f693e2b8fa027e53bda5588a0b47285d45fd6 and verified it works.